### PR TITLE
Implement backend skeleton for stage 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This starter full stack project has been generated using AlgoKit. See below for 
 6. For project-specific instructions, refer to the READMEs of the child projects:
    - Smart Contracts: [achievo-demo-contracts](projects/achievo-demo-contracts/README.md)
    - Frontend Application: [achievo-demo-frontend](projects/achievo-demo-frontend/README.md)
+   - Backend API: [backend](backend/README.md)
 
 > This project is structured as a monorepo, refer to the [documentation](https://github.com/algorandfoundation/algokit-cli/blob/main/docs/features/project/run.md) to learn more about custom command orchestration via `algokit project run`.
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,14 @@
+# Achievo Backend
+
+This module implements the backend APIs for stage 1 of the Achievo platform. It exposes RESTful endpoints for user and organisation registration, login and certificate issuance.
+
+The API is built with **FastAPI** and uses **SQLModel** with a SQLite database. Passwords are hashed using SHA256 for demonstration purposes.
+
+## Main Endpoints
+- `POST /students/register` – Register a new student.
+- `POST /students/login` – Student login.
+- `POST /organizations/register` – Register an organisation.
+- `POST /certificates/issue` – Issue a certificate NFT (stubbed).
+- `GET /certificates/{certificate_id}` – Retrieve certificate details.
+
+Tests use `pytest` and the `TestClient` from FastAPI to validate API behaviour.

--- a/backend/auth.py
+++ b/backend/auth.py
@@ -1,0 +1,9 @@
+import hashlib
+
+
+def hash_password(password: str) -> str:
+    return hashlib.sha256(password.encode()).hexdigest()
+
+
+def verify_password(password: str, password_hash: str) -> bool:
+    return hash_password(password) == password_hash

--- a/backend/db.py
+++ b/backend/db.py
@@ -1,0 +1,11 @@
+from sqlmodel import SQLModel, create_engine, Session
+
+engine = create_engine("sqlite:///database.db", echo=False)
+
+
+def init_db() -> None:
+    SQLModel.metadata.create_all(engine)
+
+
+def get_session() -> Session:
+    return Session(engine)

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,73 @@
+from fastapi import Depends, FastAPI, HTTPException
+from sqlmodel import Session, select
+
+from .db import init_db, get_session
+from .models import Student, Organization, Certificate
+from .schemas import (
+    StudentCreate,
+    StudentLogin,
+    OrganizationCreate,
+    CertificateIssue,
+)
+from .auth import hash_password, verify_password
+
+app = FastAPI(title="Achievo API")
+
+
+@app.on_event("startup")
+def on_startup() -> None:
+    init_db()
+
+
+@app.post("/students/register", status_code=201)
+def register_student(data: StudentCreate, session: Session = Depends(get_session)):
+    if session.exec(select(Student).where(Student.email == data.email)).first():
+        raise HTTPException(status_code=400, detail="Email already registered")
+    student = Student(
+        name=data.name,
+        email=data.email,
+        password_hash=hash_password(data.password),
+    )
+    session.add(student)
+    session.commit()
+    session.refresh(student)
+    return {"id": student.id, "email": student.email}
+
+
+@app.post("/students/login")
+def login_student(data: StudentLogin, session: Session = Depends(get_session)):
+    student = session.exec(select(Student).where(Student.email == data.email)).first()
+    if not student or not verify_password(data.password, student.password_hash):
+        raise HTTPException(status_code=403, detail="Invalid credentials")
+    return {"message": "login successful"}
+
+
+@app.post("/organizations/register", status_code=201)
+def register_org(data: OrganizationCreate, session: Session = Depends(get_session)):
+    org = Organization(name=data.name, docs_url=data.docs_url)
+    session.add(org)
+    session.commit()
+    session.refresh(org)
+    return {"id": org.id, "name": org.name}
+
+
+@app.post("/certificates/issue", status_code=201)
+def issue_certificate(data: CertificateIssue, session: Session = Depends(get_session)):
+    cert = Certificate(
+        student_id=data.student_id,
+        organization_id=data.organization_id,
+        course_name=data.course_name,
+        hash="placeholder-hash",
+    )
+    session.add(cert)
+    session.commit()
+    session.refresh(cert)
+    return {"id": cert.id, "hash": cert.hash}
+
+
+@app.get("/certificates/{certificate_id}")
+def get_certificate(certificate_id: int, session: Session = Depends(get_session)):
+    cert = session.get(Certificate, certificate_id)
+    if not cert:
+        raise HTTPException(status_code=404, detail="Certificate not found")
+    return cert

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,0 +1,27 @@
+from typing import Optional
+from sqlmodel import SQLModel, Field
+from datetime import datetime
+
+
+class Student(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    name: str
+    email: str
+    password_hash: str
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+
+
+class Organization(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    name: str
+    docs_url: str
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+
+
+class Certificate(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    student_id: int
+    organization_id: int
+    course_name: str
+    hash: str
+    created_at: datetime = Field(default_factory=datetime.utcnow)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,0 +1,18 @@
+[tool.poetry]
+name = "achievo-backend"
+version = "0.1.0"
+description = "FastAPI backend for Achievo stage 1"
+authors = ["devprosvn <work.devpros@gmail.com>"]
+
+[tool.poetry.dependencies]
+python = "^3.12"
+fastapi = "^0.110.0"
+uvicorn = "^0.29.0"
+sqlmodel = "^0.0.16"
+
+[tool.poetry.group.dev.dependencies]
+pytest = "*"
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -1,0 +1,23 @@
+from pydantic import BaseModel
+
+
+class StudentCreate(BaseModel):
+    name: str
+    email: str
+    password: str
+
+
+class StudentLogin(BaseModel):
+    email: str
+    password: str
+
+
+class OrganizationCreate(BaseModel):
+    name: str
+    docs_url: str
+
+
+class CertificateIssue(BaseModel):
+    student_id: int
+    organization_id: int
+    course_name: str

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -1,0 +1,22 @@
+from fastapi.testclient import TestClient
+
+from backend.main import app, init_db
+
+client = TestClient(app)
+
+
+def setup_module() -> None:
+    init_db()
+
+
+def test_register_and_login_student() -> None:
+    resp = client.post(
+        "/students/register",
+        json={"name": "Alice", "email": "alice@example.com", "password": "pwd"},
+    )
+    assert resp.status_code == 201
+    resp = client.post(
+        "/students/login",
+        json={"email": "alice@example.com", "password": "pwd"},
+    )
+    assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- add backend API using FastAPI and SQLModel
- document backend usage
- reference backend README from project root

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_b_683c371e05108327a0b03601c3aa13d1